### PR TITLE
Portf 977 unified u boot does not start on 8010

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -583,6 +583,12 @@ static void ccgr_init(void)
 }
 
 
+int board_spi_cs_gpio(unsigned bus, unsigned cs)
+{
+        return IMX_GPIO_NR(1, 20);
+}
+
+
 void board_init_f(ulong dummy) { /* SPL */
 	/* Critical - clock tree init */
 	ccgr_init();

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
@@ -54,25 +54,48 @@ static sf_env_siklu_se_t* p_sf_env_siklu_se = &sf_env_siklu_se;
 
 static int syseeprom_access_init = 0;
 
-static const char siklu_default_environment_se[] = { //
-		"SE_product_name=8010FX" ";" //
-						"SE_mac=00:24:a4:00:de:ad" ";"//
-						"SE_board_serial=F123456789" ";"//
-						"SE_system_serial=0" ";"//
-						"SE_port_map=cd--" ";" "\0" //
-		};
+static const char siklu_default_8020_environment_se[] = {
+		"SE_product_name=8020F" ";"
+		"SE_mac=00:24:a4:00:de:ad" ";"
+		"SE_board_serial=F123456789" ";"
+		"SE_system_serial=0" ";"
+		"SE_port_map=cd--" ";" "\0"
+};
+
+static const char siklu_default_8010_environment_se[] = {
+		"SE_product_name=8010FX" ";"
+		"SE_mac=00:24:a4:00:de:ad" ";"
+		"SE_board_serial=F123456789" ";"
+		"SE_system_serial=0" ";"
+		"SE_port_map=cd--" ";" "\0"
+};
+
+char *siklu_default_environment_se;
 
 /*
  * called if SYSEEPROM data was damaged or not yet created
  */
 int siklu_syseeprom_restore_default(void) {
-	int rc = 0;
+	int rc = -1;
 
 	// printf("%s() called, line %d\n", __func__, __LINE__); // edikk remove
 
+	SKL_BOARD_TYPE_E bt = siklu_get_board_type();
+	switch (bt) {
+		case SKL_BOARD_TYPE_PCB213:
+		case SKL_BOARD_TYPE_PCB217:
+			siklu_default_environment_se = siklu_default_8010_environment_se;
+			break;
+		case SKL_BOARD_TYPE_PCB277:
+			siklu_default_environment_se = siklu_default_8020_environment_se;
+			break;
+		case SKL_BOARD_TYPE_UNKNOWN:
+			return rc;
+	}
+
 	memset(p_sf_env_siklu_se->buff, 0, sizeof(sf_env_siklu_se_t));
 	memcpy(p_sf_env_siklu_se->info.data, siklu_default_environment_se,
-			sizeof(siklu_default_environment_se));
+			strlen(siklu_default_environment_se));
 	p_sf_env_siklu_se->info.control_info.data_size = strlen(
 			siklu_default_environment_se);
 	p_sf_env_siklu_se->info.control_info.crc = crc32(0L,

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
@@ -300,8 +300,7 @@ int siklu_syseeprom_udate(void) {
  *
  */
 int siklu_syseeprom_init(void) {
-	int rc = -1;
-	int err_line = 0;
+	int rc;
 	u32 crc;
 
 	printf("Init SYSEEPROM Data...\n");
@@ -310,47 +309,49 @@ int siklu_syseeprom_init(void) {
 	memset(key_val_pair, 0, sizeof(key_val_pair));
 	memset(p_sf_env_siklu_se, 0, sizeof(sf_env_siklu_se));
 
-	// read sf syseeprom area to struct
 	rc = siklu_sf_sys_eeprom_read(sf_env_siklu_se.buff,
 			sizeof(sf_env_siklu_se));
 	if (rc != 0) {
-		err_line = __LINE__;
-		goto _bad_data;
+		printf("%s() ERROR: siklu_sf_sys_eeprom_read() failed\n",
+				__func__);
+		goto _read_error;
 	}
 
-	// check valid key
 	if (p_sf_env_siklu_se->info.control_info.valid_key != VALID_KEY_WORD) {
+		printf("%s() WARNING: SEEPROM magic '0xDEADBEAF' not found\n",
+				__func__);
 		rc = -1;
-		err_line = __LINE__;
-		goto _bad_data;
-	}
-	// check data length
-	if (p_sf_env_siklu_se->info.control_info.data_size >= SIKLU_SF_ENV_SIZE) {
-		rc = -1;
-		err_line = __LINE__;
 		goto _bad_data;
 	}
 
-	// check crc
+	if (p_sf_env_siklu_se->info.control_info.data_size >=
+			SIKLU_SF_ENV_SIZE) {
+		printf("%s() WARNING: SEEPROM data_size too big\n", __func__);
+		rc = -1;
+		goto _bad_data;
+	}
+
 	crc = crc32(0L, (unsigned char *) p_sf_env_siklu_se->info.data,
 			p_sf_env_siklu_se->info.control_info.data_size);
 	if (crc != p_sf_env_siklu_se->info.control_info.crc) {
+		printf("%s() WARNING: SEEPROM stored CRC does not match "
+				"calculated CRC\n", __func__);
 		rc = -1;
-		err_line = __LINE__;
 		goto _bad_data;
 	}
 
-	// parce data, fill tuples
 	rc = siklu_fill_tupples_from_sf(p_sf_env_siklu_se);
 	if (rc != 0) {
-		err_line = __LINE__;
+		printf("%s() WARNING: Cannot parse SEEPROM data "
+				"(impossible to reach)\n", __func__);
 		goto _bad_data;
 	}
 	syseeprom_access_init = 1;
-	rc = 0;
-	return rc;
-	_bad_data: //
-	printf("%s() Error on line %d\n", __func__, err_line);
+	return 0;
+_bad_data:
+	printf("%s() SEEPROM is either not initialized or was corrupted\n",
+			__func__);
+_read_error:
 	return rc;
 
 }

--- a/board/freescale/mx6ullevk/siklu_api.h
+++ b/board/freescale/mx6ullevk/siklu_api.h
@@ -79,8 +79,6 @@ typedef enum {
 }  SKL_BOARD_TYPE_E;
 
 
-extern int board_spi_cs_gpio(unsigned bus, unsigned cs);
-
 extern int siklu_mdio_bus_connect(SIKLU_MDIO_BUS_E bus);
 
 extern int siklu_sf_sys_eeprom_read(const char* buf, int size);


### PR DESCRIPTION
This branch fixes an incorrect merge to portf-nxp-v2017.11, fdf780e552526714b1a813d99e13f9d4898b3e5c on Mon May 2 13:42:23 2022 +0300 from PORTF-901-EH8010-20-U-Boot-unification.

The merge that should have been done was from branch PORTF-827-Unified-BSP-H-merge-master.

This PR fixes the merge.

This PR also includes fixes for PORTF-

Tested locally on EH8020.

PORTF-977, PORTF-976