### PR TITLE
PORTF-990 incorrect mtdparts in kernel cmdline

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -39,7 +39,10 @@ void board_mtdparts_default(const char **mtdids, const char **mtdparts)
 	
 	if (0 == canary) {
 		ids = MTDIDS_DEFAULT;
-
+		/*
+		 * WARNING: Change similar code in mx6ullevk_siklu_pcb19x_linux.c
+		 * run_linux_code().
+		 */
 		SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
 		switch (board_type) {
 			case SKL_BOARD_TYPE_PCB195:
@@ -51,6 +54,8 @@ void board_mtdparts_default(const char **mtdids, const char **mtdparts)
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB277;
 				break;
 			default:
+				printf("Error: Unknown board type 0x%x. Using PCB_217\n",
+					board_type);
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB217;
 				break;
 		}

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
@@ -419,14 +419,17 @@ static int run_linux_code(int is_system_in_bist) {
 	const char* nand_ecc = env_get("nandEcc");
 	const char* skl_additional_kernel_cmd = env_get("extra_cmd"); // //   siklu_remarkM41  siklu additional kernel commands
 	if (!mtd_str) {
+		/*
+		 * WARNING: Change similar code in mx6ullevk.c
+		 * board_mtdparts_default().
+		 */
 		SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
-
 		switch (board_type) {
 			case SKL_BOARD_TYPE_PCB195:
-				mtd_str = MTDPARTS_DEFAULT_PCB217;
-				break;
 			case SKL_BOARD_TYPE_PCB213:
 			case SKL_BOARD_TYPE_PCB217:
+				mtd_str = MTDPARTS_DEFAULT_PCB217;
+				break;
 			case SKL_BOARD_TYPE_PCB277:
 				mtd_str = MTDPARTS_DEFAULT_PCB277;
 				break;


### PR DESCRIPTION
## Description
Fixed incorrect mtdparts in kernel command line and added warning about
changing parallel code on mx6ullevk.c and mx6ullevk_siklu_pcb19x_linux.c.

## Testing
Tested on EH8010 and EH8020 - correct Linux cmdline

## JIRA
PORTF-990