### PR TITLE
Portf 916 u boot command for resetting ethernity fixups i

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_ethernity.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_ethernity.c
@@ -23,8 +23,19 @@ static int do_siklu_ethernity_reset(cmd_tbl_t * cmdtp, int flag, int argc,
 	int rc = 0;
 	T_CPLD_LOGIC_WD_RW_REGS reset_reg;
 
+	/* Drive to 0V */
 	reset_reg.uint8 = siklu_cpld_read(R_CPLD_LOGIC_WD_RW);
 	reset_reg.s.cfg_fpga_8020_rst = 1;
+
+	rc = siklu_cpld_write(R_CPLD_LOGIC_WD_RW, reset_reg.uint8);
+	if (rc != 0) {
+		printf("%s() ERROR writing to CPLD, line %d\n", __func__, __LINE__);
+	}
+
+	mdelay(20);	/* Hold for 20ms because that's what Ethernity said to do */
+
+	/* Release back to 3.3V pullup */
+	reset_reg.s.cfg_fpga_8020_rst = 0;
 
 	rc = siklu_cpld_write(R_CPLD_LOGIC_WD_RW, reset_reg.uint8);
 	if (rc != 0) {

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 # built, which is in the current directory where this script resides. [The
 # requirement is to define this variable in the U-Boot directory is a Siklu
 # design flaw that should be fixed.]
-export PROJECT_ROOT_DIR="$(pwd)"
+#export PROJECT_ROOT_DIR="$(pwd)"
 
 # This path for the cross compiler is the Siklu standard
 export CROSS_COMPILE=/opt/arm/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf/bin/arm-none-linux-gnueabihf-
@@ -16,8 +16,8 @@ export PATH=/opt/arm/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf/bin/:$
 
 # Temporarily comment out whatever you don't need.
 #make oldconfig
-make menuconfig
-#make ARCH=arm CROSS_COMPILE=${CROSS_COMPILE} mx6ul_14x14_evk_defconfig
+#make menuconfig
+make ARCH=arm CROSS_COMPILE=${CROSS_COMPILE} mx6ull_14x14_skl_defconfig
 
-#make clean
-#make
+make clean
+make


### PR DESCRIPTION
## Description
This PR has two commits:
1. Fix for FPGA reset to drive GPIO down for only 20ms and then release, instead of driving down without release
2. Fixed defconfig filename in the build.sh convenience script

## Tests
 * Tested with scope that the ethernity_rst command in U-Boot drives GPIO down for 24ms only
 * Tested that the build.sh convenience script builds the correct configuration of U-Boot

## References
JIRA: PORTF-916