### PR TITLE
PORTF-1150 branch U-boot from before Ethernity

### DIFF
--- a/README.siklu
+++ b/README.siklu
@@ -1,0 +1,14 @@
+This README is a starting-point roadmap for understanding Siklu's changes to
+U-Boot 2017.11.
+
+Start here:
+ * include/configs/mx6ullevk_siklu.h
+
+Then see:
+ * board/freescale/mx6ullevk/mx6ullevk_siklu_*
+ * include/config/siklu/*
+ * cmd/siklu/*
+
+MTD:
+ * cmd/mtdparts.c
+    * generate_mtdparts_save() saves the mtdparts to the environment

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -39,7 +39,10 @@ void board_mtdparts_default(const char **mtdids, const char **mtdparts)
 	
 	if (0 == canary) {
 		ids = MTDIDS_DEFAULT;
-
+		/*
+		 * WARNING: Change similar code in mx6ullevk_siklu_pcb19x_linux.c
+		 * run_linux_code().
+		 */
 		SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
 		switch (board_type) {
 			case SKL_BOARD_TYPE_PCB195:
@@ -51,6 +54,8 @@ void board_mtdparts_default(const char **mtdids, const char **mtdparts)
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB277;
 				break;
 			default:
+				printf("Error: Unknown board type 0x%x. Using PCB_217\n",
+					board_type);
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB217;
 				break;
 		}

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
@@ -419,14 +419,17 @@ static int run_linux_code(int is_system_in_bist) {
 	const char* nand_ecc = env_get("nandEcc");
 	const char* skl_additional_kernel_cmd = env_get("extra_cmd"); // //   siklu_remarkM41  siklu additional kernel commands
 	if (!mtd_str) {
+		/*
+		 * WARNING: Change similar code in mx6ullevk.c
+		 * board_mtdparts_default().
+		 */
 		SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
-
 		switch (board_type) {
 			case SKL_BOARD_TYPE_PCB195:
-				mtd_str = MTDPARTS_DEFAULT_PCB217;
-				break;
 			case SKL_BOARD_TYPE_PCB213:
 			case SKL_BOARD_TYPE_PCB217:
+				mtd_str = MTDPARTS_DEFAULT_PCB217;
+				break;
 			case SKL_BOARD_TYPE_PCB277:
 				mtd_str = MTDPARTS_DEFAULT_PCB277;
 				break;

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 # built, which is in the current directory where this script resides. [The
 # requirement is to define this variable in the U-Boot directory is a Siklu
 # design flaw that should be fixed.]
-export PROJECT_ROOT_DIR="$(pwd)"
+#export PROJECT_ROOT_DIR="$(pwd)"
 
 # This path for the cross compiler is the Siklu standard
 export CROSS_COMPILE=/opt/arm/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf/bin/arm-none-linux-gnueabihf-
@@ -16,8 +16,8 @@ export PATH=/opt/arm/gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf/bin/:$
 
 # Temporarily comment out whatever you don't need.
 #make oldconfig
-make menuconfig
-#make ARCH=arm CROSS_COMPILE=${CROSS_COMPILE} mx6ul_14x14_evk_defconfig
+#make menuconfig
+make ARCH=arm CROSS_COMPILE=${CROSS_COMPILE} mx6ull_14x14_skl_defconfig
 
-#make clean
-#make
+make clean
+make


### PR DESCRIPTION
## Description
Undo the U-Boot commits for resetting the Ethernity switch done for PORTF-916:
930bc99303df567fe43a47d738010a4437a144f7
d70ac63a65c2a129f1f721090b2da33f54a7e73c
but keep the README.siklu and build.sh changes.

See also https://github.com/siklu/portfolio/pull/395

## Tests
 * Local testing only

## References
JIRA: PORTF-1150, PORTF-916