### PR TITLE
PORTF-1182 Add ubifs.default_version=4 to cmdline

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -276,6 +276,7 @@ int board_late_init(void)	/* NOT SPL */
 #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
 	env_set("board_name", "EVK");
 	env_set("board_rev", "14X14");
+	env_set("ubifs_default_version", UBIFS_DEFAULT_VERSION);
 #endif
 
 	siklu_primary_si5344d_pll_init();

--- a/include/configs/mx6ullevk_siklu.h
+++ b/include/configs/mx6ullevk_siklu.h
@@ -32,12 +32,12 @@
 #endif
 #endif
 
-
-
 #define CONFIG_CMD_MTDPARTS	/* Enable MTD parts commands */
 #define CONFIG_MTD_DEVICE	/* needed for mtdparts commands */
 #define MTDIDS_DEFAULT		"nand0=gpmi-nand" //      SPI  ;spi1=spi_flash
 #define CONFIG_SYS_MTDPARTS_RUNTIME
+
+#define UBIFS_DEFAULT_VERSION	"4"
 
 /* Note for unified U-Boot version:
  * MTDPARTS_DEFAULT is conditionally checked in cmd/mtdparts.c.


### PR DESCRIPTION
## Description
Add ubifs.default_version=4 to the default kernel command line in order to use UBIFS version 4 when formatting new partitions.
See the Jira issue for full disclosure.

## Tests
Tested locally using test procedure specified in the Jira issue.

## References
JIRA: PORTF-1182