### PR TITLE
add printout when we reboot the device

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -577,6 +577,8 @@ int siklu_board_hw_reboot(void)
  */
 static int do_siklu_board_hw_reboot(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 {
+    puts ("resetting ...\n");
+    udelay (50000);				/* wait 50 ms */
     return siklu_board_hw_reboot();
 }
 


### PR DESCRIPTION
We need to add an indication that we are going to reboot the device using the u-boot command.
The aim is to use this command in CI to make sure we reboot the device on purpose.
