### PR TITLE
PORTF-1461: u-boot board id not correct

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -569,7 +569,7 @@ static void spl_dram_init(void)
 			mx6_mmcd_calib	= &eh8020_mmcd_calib;
 			break;
 		default:
-			puts("Siklu unrecognized board id %u\n", siklu_board_id);
+			printf("Siklu unrecognized board id %u\n", siklu_board_id);
 			break;
 	}
 	mx6ul_dram_iocfg(mem_ddr->width, mx6_ddr_ioregs, mx6_grp_ioregs);

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -547,15 +547,10 @@ static void spl_dram_init(void)
 	/* See siklu_api.h for enum defs */
 	switch (siklu_board_id) {
 		case SKL_BOARD_TYPE_PCB195:
-			puts("SKL_BOARD_TYPE_PCB195\n");
 		case SKL_BOARD_TYPE_PCB213:
-			puts("SKL_BOARD_TYPE_PCB213\n");
 		case SKL_BOARD_TYPE_PCB217:
-			puts("SKL_BOARD_TYPE_PCB217\n");
 		case SKL_BOARD_TYPE_PCB295:
-			puts("SKL_BOARD_TYPE_PCB295\n");
 		case SKL_BOARD_TYPE_PCB295_AES:
-			puts("SKL_BOARD_TYPE_PCB295_AES\n");
 			/* K4B4G1646E-BMMA 500 MB
 			 * https://semiconductor.samsung.com/resources/data-sheet/DS_K4B4G1646E_BY_M_Rev1_11-0.pdf */
 			mem_ddr		= &eh8010_mem_ddr;
@@ -565,7 +560,6 @@ static void spl_dram_init(void)
 			mx6_mmcd_calib	= &eh8010_mmcd_calib;
 			break;
 		case SKL_BOARD_TYPE_PCB277: /* EH8020 */
-			puts("SKL_BOARD_TYPE_PCB277\n");
 			/* IS43TR16512B-107MBLI 1GB
 			 * https://www.issi.com/WW/pdf/43-46TR16512B-81024BL.pdf */
 			mem_ddr		= &eh8020_mem_ddr;
@@ -575,7 +569,7 @@ static void spl_dram_init(void)
 			mx6_mmcd_calib	= &eh8020_mmcd_calib;
 			break;
 		default:
-			puts("Siklu unrecognized board id\n");
+			puts("Siklu unrecognized board id %u\n", siklu_board_id);
 			break;
 	}
 	mx6ul_dram_iocfg(mem_ddr->width, mx6_ddr_ioregs, mx6_grp_ioregs);

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -52,7 +52,7 @@ void board_mtdparts_default(const char **mtdids, const char **mtdparts)
 			case SKL_BOARD_TYPE_PCB295_AES:
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB217;
 				break;
-			case SKL_BOARD_TYPE_PCB277: /* EH8020 */
+			case SKL_BOARD_TYPE_PCB277: /* EH8020F */
 				siklu_mtdparts = MTDPARTS_DEFAULT_PCB277;
 				break;
 			default:
@@ -559,7 +559,7 @@ static void spl_dram_init(void)
 			ddr_sysinfo	= &eh8010_ddr_sysinfo;
 			mx6_mmcd_calib	= &eh8010_mmcd_calib;
 			break;
-		case SKL_BOARD_TYPE_PCB277: /* EH8020 */
+		case SKL_BOARD_TYPE_PCB277: /* EH8020F */
 			/* IS43TR16512B-107MBLI 1GB
 			 * https://www.issi.com/WW/pdf/43-46TR16512B-81024BL.pdf */
 			mem_ddr		= &eh8020_mem_ddr;

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -319,7 +319,7 @@ int checkboard(void) {
 			puts("Board: Siklu PCB295_AES\n");
 			break;
 		default:
-			puts("Board: Siklu Unknown\n");
+			printf("Board: Siklu Unknown (0x%02X)\n", (int)board_type);
 			break;
 	}
 #else

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -319,7 +319,7 @@ int checkboard(void) {
 			puts("Board: Siklu PCB295_AES\n");
 			break;
 		default:
-			printf("Board: Siklu Unknown (0x%02X)\n", (int)board_type);
+			printf("Board: Siklu Unknown (0x%08X)\n", (int)board_type);
 			break;
 	}
 #else

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -100,7 +100,8 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	//static u8 is_ready = 0;
 	SKL_BOARD_TYPE_E board_type;
 	
-	printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
+	printf("calling siklu_get_board_type()\n");
+	//printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
 	printf("gd->flags=0x%x, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
 	//if ((gd->flags & GD_FLG_RELOC) == 0 || !is_ready)

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -103,6 +103,8 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	static u8 is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 
+	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x\n", (int)is_ready, (int)board_type);
+
 	if (!is_ready)
 	{
 		uint32_t reg_val;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -100,13 +100,14 @@ static void setup_iomux_siklu_cpld(void) {
  * in board/freescale/mx6ullevk/mx6ullevk.c. */
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	static int is_ready = 0;
+	static u8 is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 	
-	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x, &is_ready=%p\n", is_ready, (int)board_type, &is_ready);
+	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
 	printf("gd->flags=0x%08X, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
-	if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
+	//if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
+	if (is_ready != 1) 
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
@@ -155,9 +156,9 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			break;
 		}
 
-		if ((gd->flags & GD_FLG_RELOC) != 0) {
+//		if ((gd->flags & GD_FLG_RELOC) != 0) {
 			is_ready = 1;
-		}
+//		}
 	}
 	printf("board_type - 0x%x\n", (int)board_type);
 	return board_type;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -104,6 +104,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	static SKL_BOARD_TYPE_E board_type;
 	
 	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x, &board_type_known=%p\n", board_type_known, (int)board_type, &board_type_known);
+	printf("gd->flags=0x%08X, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
 	if (board_type_known != 1)
 	{

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -102,7 +102,7 @@ static int board_type_known = 0;
 static SKL_BOARD_TYPE_E board_type;
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x\n", board_type_known, (int)board_type);
+	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x, &board_type_known=%p\n", board_type_known, (int)board_type, &board_type_known);
 
 	if (!board_type_known)
 	{

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -100,13 +100,10 @@ static void setup_iomux_siklu_cpld(void) {
  * in board/freescale/mx6ullevk/mx6ullevk.c. */
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	static int board_type_known = 0;
+	static int is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 	
-	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x, &board_type_known=%p\n", board_type_known, (int)board_type, &board_type_known);
-	printf("gd->flags=0x%08X, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
-
-	if (board_type_known != 1)
+	if ((gd->flags & GD_FLG_RELOC == 0) || (is_ready != 1))
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
@@ -119,7 +116,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			+ ((reg_val & 1<<20)?(4):(0))
 			+ ((reg_val & 1<<21)?(8):(0));
 
-		printf("board_id - 0x%x\n",val);
+		//printf("board_id - 0x%x\n",val);
 
 		switch (val)
 		{
@@ -154,9 +151,10 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			break;
 		}
 
-		board_type_known = 1;
+		if (gd->flags & GD_FLG_RELOC != 0) {
+			is_ready = 1;
+		}
 	}
-	printf("board_type - 0x%x\n", (int)board_type);
 	return board_type;
 }
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -103,7 +103,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	static int is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 	
-	if ((gd->flags & GD_FLG_RELOC == 0) || (is_ready != 1))
+        if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
@@ -151,7 +151,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			break;
 		}
 
-		if (gd->flags & GD_FLG_RELOC != 0) {
+		if ((gd->flags & GD_FLG_RELOC) != 0) {
 			is_ready = 1;
 		}
 	}

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -106,15 +106,15 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
 	printf("gd->flags=0x%x, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
-	//if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
-	if (!is_ready)
+	if ((gd->flags & GD_FLG_RELOC) == 0 || !is_ready)
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
 		u8 val;
+		char *board_type_str = NULL;
 
 		reg_val = readl((uint32_t*)reg_addr);
-		//printf("reg_val - 0x%x\n",reg_val);
+		printf("reg_val - 0x%x\n",reg_val);
 
 		val = ((reg_val & 1<<18)?(1):(0)) + ((reg_val & 1<<19)?(2):(0))
 			+ ((reg_val & 1<<20)?(4):(0))
@@ -126,38 +126,40 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 		{
 		case 0:
 			board_type = SKL_BOARD_TYPE_PCB195;
-			env_set("siklu_board_type", "PCB195");
+			board_type_str = "PCB195";
 			break;
 		case 1:
 			board_type = SKL_BOARD_TYPE_PCB213;
-			env_set("siklu_board_type", "PCB213");
+			board_type_str = "PCB213";
 			break;
 		case 2:
 			board_type = SKL_BOARD_TYPE_PCB217;
-			env_set("siklu_board_type", "PCB217");
+			board_type_str = "PCB217";
 			break;
 		case 3:
 			board_type = SKL_BOARD_TYPE_PCB277;
-			env_set("siklu_board_type", "PCB277");
+			board_type_str = "PCB277";
 			break;
 		case 4:
 			board_type = SKL_BOARD_TYPE_PCB295;
-			env_set("siklu_board_type", "PCB295");
+			board_type_str = "PCB295";
 			break;
 		case 5:
 			board_type = SKL_BOARD_TYPE_PCB295_AES;
-			env_set("siklu_board_type", "PCB295_AES");
+			board_type_str = "PCB295_AES";
 			break;
 		default:
 			board_type = SKL_BOARD_TYPE_UNKNOWN;
-			env_set("siklu_board_type", "unknown");
+			board_type_str = "unknown";
 			printf("Error: Unknown board type 0x%x\n", val);
 			break;
 		}
 
-//		if ((gd->flags & GD_FLG_RELOC) != 0) {
+		if ((gd->flags & GD_FLG_RELOC) != 0) {
 			is_ready = 1;
-//		}
+			printf("calling env_set('siklu_board_type', '%s')\n", board_type_str);
+			env_set("siklu_board_type", board_type_str);
+		}
 	}
 	printf("board_type - %d\n", (int)board_type);
 	return board_type;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -97,70 +97,46 @@ static void setup_iomux_siklu_cpld(void) {
 /* See also spl_get_siklu_board_id() in board/freescale/mx6ullevk/mx6ullevk.c. */
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	//static u8 is_ready = 0;
 	SKL_BOARD_TYPE_E board_type;
 	
-	printf("calling siklu_get_board_type()\n");
-	//printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
-	printf("gd->flags=0x%x, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
+	uint32_t reg_val;
+	ulong reg_addr = 0x20A0000;
+	u8 val;
 
-	//if ((gd->flags & GD_FLG_RELOC) == 0 || !is_ready)
+	reg_val = readl((uint32_t*)reg_addr);
+	//printf("reg_val - 0x%x\n",reg_val);
+
+	val = ((reg_val & 1<<18)?(1):(0)) + ((reg_val & 1<<19)?(2):(0))
+		+ ((reg_val & 1<<20)?(4):(0))
+		+ ((reg_val & 1<<21)?(8):(0));
+
+	//printf("board_id - 0x%x\n",val);
+
+	switch (val)
 	{
-		uint32_t reg_val;
-		ulong reg_addr = 0x20A0000;
-		u8 val;
-		//char *board_type_str = NULL;
-
-		reg_val = readl((uint32_t*)reg_addr);
-		printf("reg_val - 0x%x\n",reg_val);
-
-		val = ((reg_val & 1<<18)?(1):(0)) + ((reg_val & 1<<19)?(2):(0))
-			+ ((reg_val & 1<<20)?(4):(0))
-			+ ((reg_val & 1<<21)?(8):(0));
-
-		//printf("board_id - 0x%x\n",val);
-
-		switch (val)
-		{
-		case 0:
-			board_type = SKL_BOARD_TYPE_PCB195;
-			//board_type_str = "PCB195";
-			break;
-		case 1:
-			board_type = SKL_BOARD_TYPE_PCB213;
-			//board_type_str = "PCB213";
-			break;
-		case 2:
-			board_type = SKL_BOARD_TYPE_PCB217;
-			//board_type_str = "PCB217";
-			break;
-		case 3:
-			board_type = SKL_BOARD_TYPE_PCB277;
-			//board_type_str = "PCB277";
-			break;
-		case 4:
-			board_type = SKL_BOARD_TYPE_PCB295;
-			//board_type_str = "PCB295";
-			break;
-		case 5:
-			board_type = SKL_BOARD_TYPE_PCB295_AES;
-			//board_type_str = "PCB295_AES";
-			break;
-		default:
-			board_type = SKL_BOARD_TYPE_UNKNOWN;
-			//board_type_str = "unknown";
-			printf("Error: Unknown board type 0x%x\n", val);
-			break;
-		}
-
-		//if ((gd->flags & GD_FLG_RELOC) != 0) {
-		//	printf("now we are ready\n");
-		//	is_ready = 1;
-			//printf("calling env_set('siklu_board_type', '%s')\n", board_type_str);
-			//env_set("siklu_board_type", board_type_str);
-		//}
+	case 0:
+		board_type = SKL_BOARD_TYPE_PCB195;
+		break;
+	case 1:
+		board_type = SKL_BOARD_TYPE_PCB213;
+		break;
+	case 2:
+		board_type = SKL_BOARD_TYPE_PCB217;
+		break;
+	case 3:
+		board_type = SKL_BOARD_TYPE_PCB277;
+		break;
+	case 4:
+		board_type = SKL_BOARD_TYPE_PCB295;
+		break;
+	case 5:
+		board_type = SKL_BOARD_TYPE_PCB295_AES;
+		break;
+	default:
+		board_type = SKL_BOARD_TYPE_UNKNOWN;
+		printf("Error: Unknown board type 0x%x\n", val);
+		break;
 	}
-	printf("board_type - %d\n", (int)board_type);
 	return board_type;
 }
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -98,13 +98,14 @@ static void setup_iomux_siklu_cpld(void) {
  * 'siklu_board_type' environment variable because this API
  * function is not available there. See also spl_get_siklu_board_id()
  * in board/freescale/mx6ullevk/mx6ullevk.c. */
-static int board_type_known = 0;
-static SKL_BOARD_TYPE_E board_type;
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
+	static int board_type_known = 0;
+	static SKL_BOARD_TYPE_E board_type;
+	
 	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x, &board_type_known=%p\n", board_type_known, (int)board_type, &board_type_known);
 
-	if (!board_type_known)
+	if (board_type_known != 1)
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -103,20 +103,24 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	static int is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 	
-        if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
+	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x, &is_ready=%p\n", is_ready, (int)board_type, &is_ready);
+	printf("gd->flags=0x%08X, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
+
+	if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
 		u8 val;
 
+		printf("checking board type\n");
 		reg_val = readl((uint32_t*)reg_addr);
-		//printf("reg_val - 0x%x\n",reg_val);
+		printf("reg_val - 0x%x\n",reg_val);
 
 		val = ((reg_val & 1<<18)?(1):(0)) + ((reg_val & 1<<19)?(2):(0))
 			+ ((reg_val & 1<<20)?(4):(0))
 			+ ((reg_val & 1<<21)?(8):(0));
 
-		//printf("board_id - 0x%x\n",val);
+		printf("board_id - 0x%x\n",val);
 
 		switch (val)
 		{
@@ -155,6 +159,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			is_ready = 1;
 		}
 	}
+	printf("board_type - 0x%x\n", (int)board_type);
 	return board_type;
 }
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -94,24 +94,21 @@ static void setup_iomux_siklu_cpld(void) {
 }
 
 
-/* Note: ./cmd/siklu/siklu_nfs_boot.c setup_bootargs() uses the
- * 'siklu_board_type' environment variable because this API
- * function is not available there. See also spl_get_siklu_board_id()
- * in board/freescale/mx6ullevk/mx6ullevk.c. */
+/* See also spl_get_siklu_board_id() in board/freescale/mx6ullevk/mx6ullevk.c. */
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	static u8 is_ready = 0;
-	static SKL_BOARD_TYPE_E board_type;
+	//static u8 is_ready = 0;
+	SKL_BOARD_TYPE_E board_type;
 	
 	printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
 	printf("gd->flags=0x%x, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
-	if ((gd->flags & GD_FLG_RELOC) == 0 || !is_ready)
+	//if ((gd->flags & GD_FLG_RELOC) == 0 || !is_ready)
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
 		u8 val;
-		char *board_type_str = NULL;
+		//char *board_type_str = NULL;
 
 		reg_val = readl((uint32_t*)reg_addr);
 		printf("reg_val - 0x%x\n",reg_val);
@@ -126,40 +123,41 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 		{
 		case 0:
 			board_type = SKL_BOARD_TYPE_PCB195;
-			board_type_str = "PCB195";
+			//board_type_str = "PCB195";
 			break;
 		case 1:
 			board_type = SKL_BOARD_TYPE_PCB213;
-			board_type_str = "PCB213";
+			//board_type_str = "PCB213";
 			break;
 		case 2:
 			board_type = SKL_BOARD_TYPE_PCB217;
-			board_type_str = "PCB217";
+			//board_type_str = "PCB217";
 			break;
 		case 3:
 			board_type = SKL_BOARD_TYPE_PCB277;
-			board_type_str = "PCB277";
+			//board_type_str = "PCB277";
 			break;
 		case 4:
 			board_type = SKL_BOARD_TYPE_PCB295;
-			board_type_str = "PCB295";
+			//board_type_str = "PCB295";
 			break;
 		case 5:
 			board_type = SKL_BOARD_TYPE_PCB295_AES;
-			board_type_str = "PCB295_AES";
+			//board_type_str = "PCB295_AES";
 			break;
 		default:
 			board_type = SKL_BOARD_TYPE_UNKNOWN;
-			board_type_str = "unknown";
+			//board_type_str = "unknown";
 			printf("Error: Unknown board type 0x%x\n", val);
 			break;
 		}
 
-		if ((gd->flags & GD_FLG_RELOC) != 0) {
-			is_ready = 1;
-			printf("calling env_set('siklu_board_type', '%s')\n", board_type_str);
-			env_set("siklu_board_type", board_type_str);
-		}
+		//if ((gd->flags & GD_FLG_RELOC) != 0) {
+		//	printf("now we are ready\n");
+		//	is_ready = 1;
+			//printf("calling env_set('siklu_board_type', '%s')\n", board_type_str);
+			//env_set("siklu_board_type", board_type_str);
+		//}
 	}
 	printf("board_type - %d\n", (int)board_type);
 	return board_type;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -98,14 +98,13 @@ static void setup_iomux_siklu_cpld(void) {
  * 'siklu_board_type' environment variable because this API
  * function is not available there. See also spl_get_siklu_board_id()
  * in board/freescale/mx6ullevk/mx6ullevk.c. */
+static int board_type_known = 0;
+static SKL_BOARD_TYPE_E board_type;
 SKL_BOARD_TYPE_E siklu_get_board_type(void)
 {
-	static u8 is_ready = 0;
-	static SKL_BOARD_TYPE_E board_type;
+	printf("calling siklu_get_board_type(), board_type_known=%d, board_type=0x%x\n", board_type_known, (int)board_type);
 
-	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x\n", (int)is_ready, (int)board_type);
-
-	if (!is_ready)
+	if (!board_type_known)
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
@@ -153,7 +152,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			break;
 		}
 
-		is_ready = 1;
+		board_type_known = 1;
 	}
 	printf("board_type - 0x%x\n", (int)board_type);
 	return board_type;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -116,7 +116,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			+ ((reg_val & 1<<20)?(4):(0))
 			+ ((reg_val & 1<<21)?(8):(0));
 
-		//printf("board_id - 0x%x\n",val);
+		printf("board_id - 0x%x\n",val);
 
 		switch (val)
 		{
@@ -153,6 +153,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 
 		is_ready = 1;
 	}
+	printf("board_type - 0x%x\n", (int)board_type);
 	return board_type;
 }
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -134,7 +134,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 		break;
 	default:
 		board_type = SKL_BOARD_TYPE_UNKNOWN;
-		printf("Error: Unknown board type 0x%x\n", val);
+		printf("Error: Unknown board type 0x%x\n", (int)val);
 		break;
 	}
 	return board_type;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -103,25 +103,24 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 	static u8 is_ready = 0;
 	static SKL_BOARD_TYPE_E board_type;
 	
-	printf("calling siklu_get_board_type(), is_ready=%d, board_type=0x%x, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
-	printf("gd->flags=0x%08X, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
+	printf("calling siklu_get_board_type(), is_ready=%d, board_type=%d, &is_ready=%p\n", (int)is_ready, (int)board_type, &is_ready);
+	printf("gd->flags=0x%x, GD_FLG_RELOC=%d\n", (int)(gd->flags), (int)(gd->flags & GD_FLG_RELOC));
 
 	//if ((gd->flags & GD_FLG_RELOC) == 0 || is_ready != 1) 
-	if (is_ready != 1) 
+	if (!is_ready)
 	{
 		uint32_t reg_val;
 		ulong reg_addr = 0x20A0000;
 		u8 val;
 
-		printf("checking board type\n");
 		reg_val = readl((uint32_t*)reg_addr);
-		printf("reg_val - 0x%x\n",reg_val);
+		//printf("reg_val - 0x%x\n",reg_val);
 
 		val = ((reg_val & 1<<18)?(1):(0)) + ((reg_val & 1<<19)?(2):(0))
 			+ ((reg_val & 1<<20)?(4):(0))
 			+ ((reg_val & 1<<21)?(8):(0));
 
-		printf("board_id - 0x%x\n",val);
+		//printf("board_id - 0x%x\n",val);
 
 		switch (val)
 		{
@@ -160,7 +159,7 @@ SKL_BOARD_TYPE_E siklu_get_board_type(void)
 			is_ready = 1;
 //		}
 	}
-	printf("board_type - 0x%x\n", (int)board_type);
+	printf("board_type - %d\n", (int)board_type);
 	return board_type;
 }
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_linux.c
@@ -379,12 +379,13 @@ static int unpack_uimage(uint uimage_ram_addr) {
 		return -1;
 	}
 	uint32_t ramd_hex_addr = ramd_addr;
+	SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
 	debugp(" Copy ROOTFS from %x to %x, size %x\n", (uint32_t)data, (uint32_t)ramd_hex_addr, (uint32_t)len);
 	memcpy((char*) ramd_hex_addr, (char*) data, len + 100);
 
 	// ############################# extract DEvice tree DTB file
 	// uimage is composed from 6 files: 1.rootfs 2.kernel 3.dtb file 4.uboot 5.mamangment convert script 6.8012 dtb file
-	if ((siklu_get_board_type() == SKL_BOARD_TYPE_PCB295) || (siklu_get_board_type() == SKL_BOARD_TYPE_PCB295_AES))
+	if ((board_type == SKL_BOARD_TYPE_PCB295) || (board_type == SKL_BOARD_TYPE_PCB295_AES))
 		sprintf(buf, "imx %x 6 " DTB_ADDR_STR, uimage_ram_addr);// same as DTB_ADDR_HEX;
 	else
 		sprintf(buf, "imx %x 3 " DTB_ADDR_STR, uimage_ram_addr);// same as DTB_ADDR_HEX;

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
@@ -95,7 +95,8 @@ int siklu_syseeprom_restore_default(void) {
 		case SKL_BOARD_TYPE_PCB277:
 			siklu_default_environment_se = siklu_default_8020F_environment_se;
 			break;
-		case SKL_BOARD_TYPE_UNKNOWN:
+		default:
+			printf("siklu_syseeprom_restore_default: Unknown board type\n");
 			return rc;
 	}
 

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_pcb19x_se_environment.c
@@ -84,8 +84,8 @@ int siklu_syseeprom_restore_default(void) {
 
 	// printf("%s() called, line %d\n", __func__, __LINE__); // edikk remove
 
-	SKL_BOARD_TYPE_E bt = siklu_get_board_type();
-	switch (bt) {
+	SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
+	switch (board_type) {
 		case SKL_BOARD_TYPE_PCB213:
 		case SKL_BOARD_TYPE_PCB217:
 		case SKL_BOARD_TYPE_PCB295:

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_soho.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_soho.c
@@ -225,8 +225,8 @@ int siklu_soho_power_up_init(void) {
 int siklu_cpu_netw_cntrl(int is_ena) {
 	int rc = 0, count;
 	T_CPLD_LOGIC_MODEM_LEDS_CTRL_REGS reset_reg;
-	SKL_BOARD_TYPE_E bt = siklu_get_board_type();
-	if (bt == SKL_BOARD_TYPE_UNKNOWN) {
+	SKL_BOARD_TYPE_E board_type = siklu_get_board_type();
+	if (board_type == SKL_BOARD_TYPE_UNKNOWN) {
 		printf("%s() Unknown Siklu board type\n", __func__);
 		return -1;
 	}
@@ -256,15 +256,15 @@ int siklu_cpu_netw_cntrl(int is_ena) {
 		}
 	}
 
-	if ((bt == SKL_BOARD_TYPE_PCB295) || (bt == SKL_BOARD_TYPE_PCB295_AES))
+	if ((board_type == SKL_BOARD_TYPE_PCB295) || (board_type == SKL_BOARD_TYPE_PCB295_AES))
 		siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT_8012, SOHO_PORT_CONTROL_REG, 0x7F);
 	else
 		siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT, SOHO_PORT_CONTROL_REG, 0x7F);
 	siklu_88e639x_reg_write(SOHO_MNGM_PORT, SOHO_PORT_CONTROL_REG, 0x7F);
 
-	if (bt != SKL_BOARD_TYPE_PCB195) {
+	if (board_type != SKL_BOARD_TYPE_PCB195) {
 		// follow setup required only for SOHO on PCB1213
-		if ((bt == SKL_BOARD_TYPE_PCB295) || (bt == SKL_BOARD_TYPE_PCB295_AES))
+		if ((board_type == SKL_BOARD_TYPE_PCB295) || (board_type == SKL_BOARD_TYPE_PCB295_AES))
 			rc = siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT_8012, 0, 0xD05);
 		else
 			rc = siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT, 0, 0xD05);

--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_soho.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_soho.c
@@ -225,6 +225,11 @@ int siklu_soho_power_up_init(void) {
 int siklu_cpu_netw_cntrl(int is_ena) {
 	int rc = 0, count;
 	T_CPLD_LOGIC_MODEM_LEDS_CTRL_REGS reset_reg;
+	SKL_BOARD_TYPE_E bt = siklu_get_board_type();
+	if (bt == SKL_BOARD_TYPE_UNKNOWN) {
+		printf("%s() Unknown Siklu board type\n", __func__);
+		return -1;
+	}
 
 	// 1. un-reset SOHO chip
 	reset_reg.uint8 = siklu_cpld_read(R_CPLD_LOGIC_MODEM_LEDS_CTRL);
@@ -251,15 +256,15 @@ int siklu_cpu_netw_cntrl(int is_ena) {
 		}
 	}
 
-	if ((siklu_get_board_type() == SKL_BOARD_TYPE_PCB295) || (siklu_get_board_type() == SKL_BOARD_TYPE_PCB295_AES))
+	if ((bt == SKL_BOARD_TYPE_PCB295) || (bt == SKL_BOARD_TYPE_PCB295_AES))
 		siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT_8012, SOHO_PORT_CONTROL_REG, 0x7F);
 	else
 		siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT, SOHO_PORT_CONTROL_REG, 0x7F);
 	siklu_88e639x_reg_write(SOHO_MNGM_PORT, SOHO_PORT_CONTROL_REG, 0x7F);
 
-	if (siklu_get_board_type() != SKL_BOARD_TYPE_PCB195) {
+	if (bt != SKL_BOARD_TYPE_PCB195) {
 		// follow setup required only for SOHO on PCB1213
-		if ((siklu_get_board_type() == SKL_BOARD_TYPE_PCB295) || (siklu_get_board_type() == SKL_BOARD_TYPE_PCB295_AES))
+		if ((bt == SKL_BOARD_TYPE_PCB295) || (bt == SKL_BOARD_TYPE_PCB295_AES))
 			rc = siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT_8012, 0, 0xD05);
 		else
 			rc = siklu_88e639x_reg_write(SOHO_HOST_CPU_PORT, 0, 0xD05);


### PR DESCRIPTION
Fixed board id display.
Before the fix the Board was displayed as: `Siklu Unknown`:

```
Reset cause: POR
Model: Siklu TBD
Board: Siklu Unknown
I2C:   ready
DRAM:  512 MiB
```

After the fix:
```
CPU:   Freescale i.MX6ULL rev1.1 528 MHz (running at 396 MHz)
CPU:   Industrial temperature grade (-40C to 105C) at 39C
Reset cause: POR
Model: Siklu TBD
Board: Siklu PCB213
I2C:   ready
DRAM:  512 MiB
NAND:  128 MiB
In:    serial
```

The root cause of the problem was that u-boot tried to access a static variable that was not accessible from the code that was not relocated to the RAM.

The fix was tested by @moshellib 

Reference: PORTF-1461
