### PR TITLE
PORTF-1808-EH8020-sled-u-boot-command

### DIFF
--- a/board/freescale/mx6ullevk/cpld_reg.h
+++ b/board/freescale/mx6ullevk/cpld_reg.h
@@ -235,10 +235,14 @@ typedef union
 	u8 uint8;
 	struct
 	{
-		u8 cfg_eth1_led_color:1;	// 0 - green , 1 - yellow
-		u8 cfg_eth2_0_led_color:1;	// 0 - green , 1 - yellow
-		u8 cfg_eth2_1_led_color:1;	// 0 - green , 1 - yellow
-		u8 padding0:5;
+        u8 cfg_eth1_led_color:1;    // 0 - green , 1 - yellow
+        u8 cfg_eth2_0_led_color:1;  // 0 - green , 1 - yellow
+        u8 cfg_eth2_1_led_color:1;  // 0 - green , 1 - yellow
+        u8 cfg_xpic_led_color:1;    // 0 - green , 1 - yellow
+        u8 cfg_dummy_1:1;           // 0 - not used
+        u8 cfg_eth2_led_state:1;    // 0 - on , 1 - off
+        u8 cfg_eth3_led_state:1;    // 0 - on , 1 - off
+        u8 cfg_xpic_led_state:1;    // 0 - on , 1 - off
 	} s;
 } T_CPLD_LOGIC_ETHERNET_LEDS_CTRL_REGS;
 

--- a/board/freescale/mx6ullevk/siklu_api.h
+++ b/board/freescale/mx6ullevk/siklu_api.h
@@ -57,7 +57,10 @@ typedef enum {
     SKL_LED_ETH1,
     SKL_LED_ETH2_0,
     SKL_LED_ETH2_1,
+    SKL_LED_ETH2,
+    SKL_LED_ETH3,
     SKL_LED_POWER,
+    SKL_LED_XPIC,
     SKL_LED_ALL,
 } SKL_BOARD_LED_TYPE_E;
 


### PR DESCRIPTION
for 8020 platform we need to change the u-boot sled BIST command.
The command syntax is: sled [led] [state]  .
For 8020 sled command  support LEDs: eth1/eth2/eth3/modem/power/xpic/all

EH8020 test:
=> sled help
sled [led] [state]
 led:   eth1/eth2/eth3/modem/power/xpic/all
 state:
        o - off
        g - green
        y - yellow
        gb - green blink
        yb - yellow blink


=> sled eth2 o
=> sled eth2 g
=> sled eth2 y
=> sled eth2 gb
 Error or unsupported mode
=> sled eth2 yb
 Error or unsupported mode

=> sled eth3 o
=> sled eth3 g
=> sled eth3 y
=> sled eth3 gb
 Error or unsupported mode
=> sled eth3 yb
 Error or unsupported mode

=> sled xpic o
=> sled xpic g
=> sled xpic y
=> sled xpic gb
 Error or unsupported mode
=> sled xpic yb
 Error or unsupported mode

=> sled all o
=> sled all g
=> sled all y
