### PR TITLE
PORTF-1855: Remove-BIST-mode-2-from-u-boot

### DIFF
--- a/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
+++ b/board/freescale/mx6ullevk/mx6ullevk_siklu_hw.c
@@ -659,8 +659,7 @@ typedef enum
 {
     BIST_MODE_DISABLED = 0,
     BIST_MODE_ON = 1,
-    BIST_MODE_AND_MONITORING = 2,
-    BIST_MODE_LAST = BIST_MODE_AND_MONITORING,
+    BIST_MODE_LAST = BIST_MODE_ON,
 } BIST_MODE_E;
 
 /*
@@ -690,9 +689,6 @@ static int do_siklu_board_bist_mode(cmd_tbl_t *cmdtp, int flag, int argc, char *
             case BIST_MODE_ON:
                 printf("System in BIST mode\n");
                 break;
-            case BIST_MODE_AND_MONITORING:
-                printf("System in BIST mode with Monitoring\n");
-                break;
             default:
                 printf("Wrong BIST mode! Disable BIST for future runs\n");
                 env_set(SIKLU_BIST_ENVIRONMENT_NAME, NULL);
@@ -716,10 +712,6 @@ static int do_siklu_board_bist_mode(cmd_tbl_t *cmdtp, int flag, int argc, char *
         case BIST_MODE_ON:
             printf("Set System in BIST mode\n");
             env_set(SIKLU_BIST_ENVIRONMENT_NAME, "1");
-            break;
-        case BIST_MODE_AND_MONITORING:
-            printf("System in BIST mode with Monitoring\n");
-            env_set(SIKLU_BIST_ENVIRONMENT_NAME, "2");
             break;
         default:
             printf("Wrong BIST mode! Disable BIST for future runs\n");

--- a/config.mk
+++ b/config.mk
@@ -32,7 +32,7 @@ VENDOR :=
 # UBOOT_MAJOR_STR, UBOOT_MINOR_STR, and UBOOT_BUILD_STR parsed in script ~/sdk_nxp/host-scripts/create_target_uboot.sh
 
 UBOOT_MAJOR_STR = "21"
-UBOOT_MINOR_STR = "0"
+UBOOT_MINOR_STR = "1"
 UBOOT_BUILD_STR = "0"
 
 # For the following line to work when building U-Boot outside of the portfolio


### PR DESCRIPTION
1. Remove BIST mode 2 from u-boot.
2. Update u-boot version number to 21.1.0